### PR TITLE
Always use the system CA

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -12,4 +12,7 @@ RUN dnf install -y --setopt=tsflags=nodocs \
 
 COPY . /usr/local/.
 
+# Always use the system CA.  There's no reason not to.
+ENV REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
+
 RUN pip3 install --no-dependencies -r /usr/local/requirements.txt


### PR DESCRIPTION
There's no reason not to since we know which base image we are building on.