### PR TITLE
Revert "Use markdown-to-confluence.py as an entrypoint"

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -16,5 +16,3 @@ COPY . /usr/local/.
 ENV REQUESTS_CA_BUNDLE=/etc/pki/tls/certs/ca-bundle.crt
 
 RUN pip3 install --no-dependencies -r /usr/local/requirements.txt
-
-ENTRYPOINT ["/usr/local/bin/markdown-to-confluence.py"]

--- a/README.md
+++ b/README.md
@@ -57,6 +57,7 @@ To mount the current working directory at `/src` and have
 
 ```
 $ podman run --rm -it -v .:/src:Z quay.io/rbean/markdown-to-confluence \
+    /usr/local/bin/markdown-to-confluence.py \
     --confluence-url https://confluence.example.org \
     --confluence-space SPACE \
     --root /src --path doc --dry-run
@@ -66,8 +67,7 @@ To start the container with the current working directory at `/src` and work
 interactively:
 
 ```
-$ podman run --rm -it -v .:/src:Z --entrypoint /bin/bash \
-    quay.io/rbean/markdown-to-confluence
+$ podman run --rm -it -v .:/src:Z quay.io/rbean/markdown-to-confluence
 # markdown-to-confluence.py \
     --confluence-url https://confluence.example.org \
     --confluence-space SPACE \


### PR DESCRIPTION
This reverts commit 4f2c7773e3d212e22eaf5095a46e29b4fafaeaca, undoing #16.