### PR TITLE
Support authenticating with confluence personal access token

### DIFF
--- a/README.md
+++ b/README.md
@@ -12,9 +12,17 @@ wiki markup and publish them.
 
 ## Authentication
 
-The `CONFLUENCE_USERNAME` and `CONFLUENCE_PASSWORD` environment variables must
-be set to the username and password of an account with appropriate permissions.
+This utility supports authenticating to confluence with personal access token or
+username and password.
 
+When the environment variable `CONFLUENCE_TOKEN` is defined, it will authenticate
+to confluence with personal access token.
+
+When `CONFLUENCE_TOKEN` is not defined, it will look for the `CONFLUENCE_USERNAME`
+and `CONFLUENCE_PASSWORD` environment variables, they should be defined to
+authenticate to confluence with username and password.
+
+Authentication is not required while running in dry-run mode.
 
 ## Confluence and Markdown
 


### PR DESCRIPTION
Authenticate to confluence with personal access token when `CONFLUENCE_TOKEN` is defined, otherwise use username and password.

The previous version `42b7e46` has authentication enforced in dry-run mode by mistake.